### PR TITLE
Added intermediate gradient calculation

### DIFF
--- a/docs/linear_regression.rst
+++ b/docs/linear_regression.rst
@@ -146,6 +146,12 @@ We can calculate the gradient of this cost function as:
        \frac{df}{db}\\
       \end{bmatrix}
   =
+    \begin{bmatrix}
+      \frac{1}{N} \sum -x_i \cdot 2(y_i - (mx_i + b)) \\
+      \frac{1}{N} \sum -1 \cdot 2(y_i - (mx_i + b)) \\
+    \end{bmatrix}
+    
+  =
      \begin{bmatrix}
        \frac{1}{N} \sum -2x_i(y_i - (mx_i + b)) \\
        \frac{1}{N} \sum -2(y_i - (mx_i + b)) \\


### PR DESCRIPTION
Added an intermediate calculation to hopefully clarify how the chain rule is working.
![image](https://user-images.githubusercontent.com/14948437/51730330-ef2e9200-202b-11e9-9ee5-88e8aa640fac.png)
I'm pretty new to reST. Is there a way to align the equal signs nicely?