### PR TITLE
docs: glossary neural network

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -80,12 +80,12 @@ Deduction
 .. _glossary_deep_learning:
 
 Deep Learning
-  Deep Learning is derived from one machine learning algorithm called perceptron or malti layer perceptron that gain more and more attention nowadays because of its success in different fields like, computer vision to signal processing and medical diagnosis to self-driving cars. As all other AI algorithms deep learning is from decades, but now today we have more and more data and cheap computing power that make this algorithm really powerful to achive state of the art acuracy. in modern world this algorithm knowns as artificial neural network. deep learning is much more than traditional artificial neural network. but it was highly influenced by machine learning's neural network and perceptron network.
+  Deep Learning is derived from one machine learning algorithm called perceptron or multi layer perceptron that gain more and more attention nowadays because of its success in different fields like, computer vision to signal processing and medical diagnosis to self-driving cars. As all other AI algorithms deep learning is from decades, but now today we have more and more data and cheap computing power that make this algorithm really powerful to achieve state of the art accuracy. In modern world this algorithm knowns as artificial neural network. deep learning is much more than traditional artificial neural network. But it was highly influenced by machine learning's neural network and perceptron network.
 
 .. _glossary_dimension:
 
 Dimension
-  Dimention for machine learning and data scientist is differ from physics, here Dimention of data means how much feature you have in you data ocean(data-set). e.g in case of object detection application, flatten image size and color channel(e.g 28*28*3) is a feature of the input set.  in case of house price pridiction (maybe) house size is the data-set so we call it 1 dimentional data.
+  Dimention for machine learning and data scientist is differ from physics, here Dimention of data means how much feature you have in you data ocean(data-set). e.g in case of object detection application, flatten image size and color channel(e.g 28*28*3) is a feature of the input set. In case of house price prediction (maybe) house size is the data-set so we call it 1 dimentional data.
 
 .. _glossary_epoch:
 
@@ -120,7 +120,7 @@ Hyperparameters
 .. _glossary_induction:
 
 Induction
-  A bottoms-up approach to answering questions or solving problems. A logic technique that goes from observations to theory. E.g. We keep observing X, so we <b><i>infer</i></b> that Y must be True.
+  A bottoms-up approach to answering questions or solving problems. A logic technique that goes from observations to theory. E.g. We keep observing X, so we infer that Y must be True.
 
 .. _glossary_instance:
 
@@ -135,7 +135,7 @@ Learning Rate
 .. _glossary_loss:
 
 Loss
-  Loss = true_value(from data-set)- predicted value(from ML-model)  The lower the loss, the better a model (unless the model has over-fitted to the training data). The loss is calculated on training and validation and its interperation is how well the model is doing for these two sets. Unlike accuracy, loss is not a percentage. It is a summation of the errors made for each example in training or validation sets.
+  Loss = true_value(from data-set)- predicted value(from ML-model)  The lower the loss, the better a model (unless the model has over-fitted to the training data). The loss is calculated on training and validation and its interpretation is how well the model is doing for these two sets. Unlike accuracy, loss is not a percentage. It is a summation of the errors made for each example in training or validation sets.
 
 .. _glossary_machine_learning:
 
@@ -164,7 +164,7 @@ Normalization
 .. _glossary_null_accuracy:
 
 Null Accuracy
-  Baseline accuracy that can be acheived by always predicting the most frequent class ("B has the highest frequency, so lets guess B every time").
+  Baseline accuracy that can be achieved by always predicting the most frequent class ("B has the highest frequency, so lets guess B every time").
 
 .. _glossary_observation:
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -80,7 +80,7 @@ Deduction
 .. _glossary_deep_learning:
 
 Deep Learning
-  Deep Learning is derived from one machine learning algorithm called perceptron or malti layer perceptron that gain more and more attention nowadays because of its success in different fields like, computer vision to signal processing and medical diagnosis to self-driving cars. As all other AI algorithms deep learning is from decades, but now today we have more and more data and cheap computing power that make this algorithm really powerful to achive state of the art acuracy. in modern world this algorithm knowns as artificial neural network. deep learning is much more than traditional artificial neural network. but it was highly influenced by machine learning's neural network and perceptron network. 
+  Deep Learning is derived from one machine learning algorithm called perceptron or malti layer perceptron that gain more and more attention nowadays because of its success in different fields like, computer vision to signal processing and medical diagnosis to self-driving cars. As all other AI algorithms deep learning is from decades, but now today we have more and more data and cheap computing power that make this algorithm really powerful to achive state of the art acuracy. in modern world this algorithm knowns as artificial neural network. deep learning is much more than traditional artificial neural network. but it was highly influenced by machine learning's neural network and perceptron network.
 
 .. _glossary_dimension:
 
@@ -105,7 +105,7 @@ Feature
 .. _glossary_feature_selection:
 
 Feature Selection
-  Feature selection is the process of selecting relevant features from a data-set for creating a Machine Learning model. 
+  Feature selection is the process of selecting relevant features from a data-set for creating a Machine Learning model.
 
 .. _glossary_feature_vector:
 
@@ -135,14 +135,14 @@ Learning Rate
 .. _glossary_loss:
 
 Loss
-  Loss = true_value(from data-set)- predicted value(from ML-model)  The lower the loss, the better a model (unless the model has over-fitted to the training data). The loss is calculated on training and validation and its interperation is how well the model is doing for these two sets. Unlike accuracy, loss is not a percentage. It is a summation of the errors made for each example in training or validation sets. 
+  Loss = true_value(from data-set)- predicted value(from ML-model)  The lower the loss, the better a model (unless the model has over-fitted to the training data). The loss is calculated on training and validation and its interperation is how well the model is doing for these two sets. Unlike accuracy, loss is not a percentage. It is a summation of the errors made for each example in training or validation sets.
 
 .. _glossary_machine_learning:
 
 Machine Learning
    Mitchell (1997) provides a succinct definition: “A computer program is said to learn from experience E with respect to some
 class of tasks T and performance measure P, if its performance at tasks in T , as measured by P, improves with experience E.In
-simple language machine learning is a field in which human made algorithms have an ability learn by itself or predict future 
+simple language machine learning is a field in which human made algorithms have an ability learn by itself or predict future
 for unseen data.
 
 
@@ -154,7 +154,8 @@ Model
 .. _glossary_neural_networks:
 
 Neural Networks
-  Contribute a definition!
+  A model that, taking inspiration from the brain, is composed of layers (at least one of which is hidden) consisting of simple connected units or neurons followed by nonlinearities.
+  It can be trained to recognize patterns. Neurons in each layer learn increasingly abstract representations of the data.
 
 .. _glossary_normalization:
 


### PR DESCRIPTION
Added the definition from [google's glossary](https://developers.google.com/machine-learning/glossary/#neural_network) and [tensorflow's anatomy of a neural network](https://www.tensorflow.org/about/#tab-3).

Other changes are just trailing spaces from the same file.
edit: 2nd commit fixes a bunch of typos in the glossary file.


![](https://i.imgur.com/6jbTKli.png)