### PR TITLE
Update activation_functions.rst // misprint

### DIFF
--- a/docs/activation_functions.rst
+++ b/docs/activation_functions.rst
@@ -57,7 +57,7 @@ ELU is very similiar to RELU except negative inputs. They are both in identity f
 +-------------------------------------------------------+------------------------------------------------------+
 | .. math::                                             | .. math::                                            |
 |      R(z) = \begin{Bmatrix} z & z > 0 \\              |       R'(z) = \begin{Bmatrix} 1 & z>0 \\             |
-|       α.( e^z – 1) & z <= 0 \end{Bmatrix}             |       α.e^z & z<0 \end{Bmatrix}                      |
+|       α.( np.exp(z) – 1) & z <= 0 \end{Bmatrix}             |       α.e^z & z<0 \end{Bmatrix}                      |
 +-------------------------------------------------------+------------------------------------------------------+
 | .. image:: images/elu.png                             | .. image:: images/elu_prime.png                      |
 |       :align: center                                  |      :align: center                                  |


### PR DESCRIPTION
Hi, I've just stumbled upon a little misprint in ELU block python code. I believe we should use "np.exp(z)" instead of "e^z" (or declare variable "e").